### PR TITLE
Implement getPixelColor() and setBrightness()

### DIFF
--- a/src/WS2812B.cpp
+++ b/src/WS2812B.cpp
@@ -172,6 +172,31 @@ uint32_t WS2812B::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
   return ((uint32_t)w << 24) | ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
 }
 
+uint32_t WS2812B::getPixelColor(uint16_t n) const {
+  if(n >= numLEDs) return 0; // Out of bounds, return no color.
+
+  // Extract the g,r,b values from the 3 bit encoded data.
+  // A positive bit of rgb appears in the middle (2nd) bit of the encoded 3 bit tuple.
+  // Encoded bit positions for a single pixel byte: -7--6--5,--4--3--,2--1--0-
+  uint8_t *bptr = pixels + (n<<3) + n +1;
+  uint8_t grb[3] = {0, 0, 0};
+  for(uint8_t i = 0; i < 3; i++) {
+    grb[i] |= (*bptr & 0b01000000) << 1; // bit 7
+    grb[i] |= (*bptr & 0b00001000) << 3; // bit 6
+    grb[i] |= (*bptr & 0b00000001) << 5; // bit 5
+    bptr++;
+    grb[i] |= (*bptr & 0b00100000) >> 1; // bit 4
+    grb[i] |= (*bptr & 0b00000100) << 1; // bit 3
+    bptr++;
+    grb[i] |= (*bptr & 0b10000000) >> 5; // bit 2
+    grb[i] |= (*bptr & 0b00010000) >> 3; // bit 1
+    grb[i] |= (*bptr & 0b00000010) >> 1; // bit 0
+    bptr++;
+  }
+  return ((uint32_t)grb[1] << 16) |
+         ((uint32_t)grb[0] <<  8) |
+          (uint32_t)grb[2];
+}
 
 uint16_t WS2812B::numPixels(void) const {
   return numLEDs;

--- a/src/WS2812B.cpp
+++ b/src/WS2812B.cpp
@@ -240,8 +240,8 @@ void WS2812B::setBrightness(uint8_t b) {
             *ptr,
             oldBrightness = brightness - 1; // De-wrap old brightness value
     uint16_t scale;
-    if (oldBrightness == 0) scale = 0; // Avoid /0
-    else if (b == 255) scale = 65535 / oldBrightness;
+    if(oldBrightness == 0) scale = 0; // Avoid /0
+    else if(b == 255) scale = 65535 / oldBrightness;
     else scale = (((uint16_t)newBrightness << 8) - 1) / oldBrightness;
     
     brightness = 0; // Turn off brightness scaling in setPixelColor

--- a/src/WS2812B.h
+++ b/src/WS2812B.h
@@ -76,8 +76,6 @@ class WS2812B {
     Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w);
  // uint32_t
  //   getPixelColor(uint16_t n) const;
-  inline bool
-    canShow(void) { return (micros() - endTime) >= 300L; }
 
 	private:
 
@@ -90,13 +88,7 @@ class WS2812B {
   uint8_t
     brightness,
    *pixels,        // Holds the current LED color values, which the external API calls interact with 9 bytes per pixel + start + end empty bytes
-   *doubleBuffer,	// Holds the start of the double buffer (1 buffer for async DMA transfer and one for the API interaction.
-    rOffset,       // Index of red byte within each 3- or 4-byte pixel
-    gOffset,       // Index of green byte
-    bOffset,       // Index of blue byte
-    wOffset;       // Index of white byte (same as rOffset if no white)
-  uint32_t
-    endTime;       // Latch timing reference
+   *doubleBuffer;	// Holds the start of the double buffer (1 buffer for async DMA transfer and one for the API interaction.
 };
 
 

--- a/src/WS2812B.h
+++ b/src/WS2812B.h
@@ -74,8 +74,8 @@ class WS2812B {
   static uint32_t
     Color(uint8_t r, uint8_t g, uint8_t b),
     Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w);
- // uint32_t
- //   getPixelColor(uint16_t n) const;
+  uint32_t
+    getPixelColor(uint16_t n) const;
 
 	private:
 


### PR DESCRIPTION
I've implemented these two functions as they behave in the Adafruit_Neopixel library for better compatibility.

The getPixelColor() implementation is particularly inefficient and could probably use a rewrite in assembly. But at the STM32 clock speeds it probably doesn't even matter.